### PR TITLE
Allow for HTTPS Proxy Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ BOTMOCK_PROJECT_ID=@botmock-project-id
 
 To get your Botmock API token, follow the [guide](http://help.botmock.com/en/articles/2334581-developer-api).
 
+Optionally, custom subdomain can be used by defining
+
+```shell
+SUBDOMAIN="ww2"
+```
+
+Also, configuring the client HTTP agent to reject unauthorized requests can be accomplished through
+
+```shell
+shouldRejectUnauthorized="false"
+```
+
 ### Commands
 
 #### `start`

--- a/README.md
+++ b/README.md
@@ -61,25 +61,13 @@ npm i
 Create `.env` in `/botmock-lex-export` and fill in values for the following:
 
 ```shell
-BOTMOCK_TOKEN=@botmock-token
-BOTMOCK_TEAM_ID=@botmock-team-id
-BOTMOCK_BOARD_ID=@botmock-board-id
-BOTMOCK_PROJECT_ID=@botmock-project-id
+BOTMOCK_TOKEN="token"
+BOTMOCK_TEAM_ID="team_id"
+BOTMOCK_BOARD_ID="board_id"
+BOTMOCK_PROJECT_ID="project_id"
 ```
 
 To get your Botmock API token, follow the [guide](http://help.botmock.com/en/articles/2334581-developer-api).
-
-Optionally, custom subdomain can be used by defining
-
-```shell
-SUBDOMAIN="ww2"
-```
-
-Also, configuring the client HTTP agent to reject unauthorized requests can be accomplished through
-
-```shell
-shouldRejectUnauthorized="false"
-```
 
 ### Commands
 

--- a/index.ts
+++ b/index.ts
@@ -28,16 +28,19 @@ async function main(argV: string[]): Promise<void> {
   log("creating output directories");
   await recreateOutputDirectories({ outputPath: outputDirectory, });
   log("fetching project data");
-  const shouldRejectUnauthorized = typeof process.env.SHOULD_REJECT_UNAUTHORIZED !== "undefined"
-    ? JSON.parse(process.env.SHOULD_REJECT_UNAUTHORIZED.toLowerCase())
-    : undefined;
-  const subdomain = typeof process.env.SUBDOMAIN !== "undefined"
-    ? JSON.parse(process.env.SUBDOMAIN)
-    : undefined;
+  let shouldRejectUnauthorized: boolean | undefined;
+  switch (process.env.SHOULD_REJECT_UNAUTHORIZED) {
+    case "true":
+      shouldRejectUnauthorized = true;
+      break;
+    case "false":
+      shouldRejectUnauthorized = false;
+      break;
+  }
   const { data: projectData } = await new Batcher({
     clientConfig: {
       token: process.env.BOTMOCK_TOKEN as string,
-      subdomain,
+      subdomain: process.env.SUBDOMAIN,
       shouldRejectUnauthorized,
     },
     projectConfig: {

--- a/index.ts
+++ b/index.ts
@@ -29,10 +29,16 @@ async function main(argV: string[]): Promise<void> {
   await recreateOutputDirectories({ outputPath: outputDirectory, });
   log("fetching project data");
   const { data: projectData } = await new Batcher({
-    token: process.env.BOTMOCK_TOKEN as string,
-    teamId: process.env.BOTMOCK_TEAM_ID as string,
-    projectId: process.env.BOTMOCK_PROJECT_ID as string,
-    boardId: process.env.BOTMOCK_BOARD_ID as string,
+    clientConfig: {
+      token: process.env.BOTMOCK_TOKEN as string,
+      subdomain: process.env.SUBDOMAIN as any,
+      shouldRejectUnauthorized: process.env.SHOULD_REJECT_UNAUTHORIZED as any,
+    },
+    projectConfig: {
+      teamId: process.env.BOTMOCK_TEAM_ID as string,
+      projectId: process.env.BOTMOCK_PROJECT_ID as string,
+      boardId: process.env.BOTMOCK_BOARD_ID as string,
+    }
   }).batchRequest([
     "project",
     "board",

--- a/index.ts
+++ b/index.ts
@@ -28,11 +28,17 @@ async function main(argV: string[]): Promise<void> {
   log("creating output directories");
   await recreateOutputDirectories({ outputPath: outputDirectory, });
   log("fetching project data");
+  const shouldRejectUnauthorized = typeof process.env.SHOULD_REJECT_UNAUTHORIZED !== "undefined"
+    ? JSON.parse(process.env.SHOULD_REJECT_UNAUTHORIZED.toLowerCase())
+    : undefined;
+  const subdomain = typeof process.env.SUBDOMAIN !== "undefined"
+    ? JSON.parse(process.env.SUBDOMAIN)
+    : undefined;
   const { data: projectData } = await new Batcher({
     clientConfig: {
       token: process.env.BOTMOCK_TOKEN as string,
-      subdomain: process.env.SUBDOMAIN as any,
-      shouldRejectUnauthorized: process.env.SHOULD_REJECT_UNAUTHORIZED as any,
+      subdomain,
+      shouldRejectUnauthorized,
     },
     projectConfig: {
       teamId: process.env.BOTMOCK_TEAM_ID as string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,9 +207,9 @@
       }
     },
     "@botmock-api/client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@botmock-api/client/-/client-1.1.0.tgz",
-      "integrity": "sha512-eArCUTMD2M+ExCBscf2ggenzARL0qdGHCK7wpM2ysLIp01R4EEsxXenN/nlnJ+tZhNt4s/8ICO64DR2LUz8e5A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@botmock-api/client/-/client-1.2.0.tgz",
+      "integrity": "sha512-5WJTGGboa7+jhNB87pLmozhS+UI6WOCFn+1jUQULq2ku1hQfOs6x8SuLhZxfILyLlw9KSaTlkkePLibvu2LujA==",
       "requires": {
         "node-fetch": "^2.6.0"
       }
@@ -548,9 +548,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-globals": {
@@ -576,6 +576,29 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "ajv": {
       "version": "6.10.2",
@@ -1043,13 +1066,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -2270,18 +2286,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
-      "integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2365,6 +2369,12 @@
         "whatwg-encoding": "^1.0.1"
       }
     },
+    "html-escaper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+      "dev": true
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2374,6 +2384,30 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "iconv-lite": {
@@ -2711,12 +2745,12 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "jest": {
@@ -3432,9 +3466,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mixin-deep": {
@@ -3511,12 +3545,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nice-try": {
@@ -3674,24 +3702,6 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -4725,17 +4735,6 @@
       "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
-      "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -4913,12 +4912,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,9 +207,9 @@
       }
     },
     "@botmock-api/client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@botmock-api/client/-/client-1.0.0.tgz",
-      "integrity": "sha512-mmEE6G+ySZPchIANIagqobszRpd9dVaub58RFnL6/XeGAV65nSpDLzDGbVAGUgDU93FD/j8jjqq2Ysrjph8+lQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@botmock-api/client/-/client-1.1.0.tgz",
+      "integrity": "sha512-eArCUTMD2M+ExCBscf2ggenzARL0qdGHCK7wpM2ysLIp01R4EEsxXenN/nlnJ+tZhNt4s/8ICO64DR2LUz8e5A==",
       "requires": {
         "node-fetch": "^2.6.0"
       }
@@ -564,9 +564,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -3251,9 +3251,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@botmock-api/client": "1.0.0",
+    "@botmock-api/client": "^1.1.0",
     "@botmock-api/entity-map": "^0.3.0",
     "@botmock-api/flow": "^0.7.0",
     "@botmock-api/log": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@botmock-api/client": "^1.1.0",
+    "@botmock-api/client": "^1.2.0",
     "@botmock-api/entity-map": "^0.3.0",
     "@botmock-api/flow": "^0.7.0",
     "@botmock-api/log": "^0.2.0",
@@ -37,6 +37,7 @@
     "cross-zip": "^3.0.0",
     "dotenv": "^8.2.0",
     "fs-extra": "8.1.0",
+    "https-proxy-agent": "^5.0.0",
     "node-fetch": "2.6.0",
     "uuid": "^3.3.3"
   },


### PR DESCRIPTION
Resolves #15 
This PR uses the latest version of `@botmock-api/client` which allows for custom `subdomain` and `shouldRejectUnauthorized` to be passed to the inner HTTP client.

## Usage

The script can now (optionally) accept `process.env.SUBDOMAIN` and `process.env.SHOULD_REJECT_UNAUTHORIZED`.

```console
SUBDOMAIN="ww2"
SHOULD_REJECT_UNAUTHORIZED="false"
```